### PR TITLE
Update .gitignore with additional Python patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,21 @@
 venv/
+.venv/
+env/
+.env
+.python-version
+.coverage
+htmlcov/
 .vscode/
 __pycache__/
+*.py[cod]
+*$py.class
+*.so
 test.db
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
 
 # OS generated files #
 ######################
@@ -15,3 +29,7 @@ Thumbs.db
 
 # IntelliJ
 .idea/
+
+# Logs
+*.log
+logs/


### PR DESCRIPTION
Added additional common Python-related patterns to .gitignore:
- More virtual environment patterns
- Python distribution and packaging files
- Coverage report files
- Compiled Python file patterns
- Log file patterns